### PR TITLE
[feat] 사용자는 주간 투표 기능을 활성화/비활성화할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     //webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.projectreactor:reactor-core'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/specialwarriors/conal/common/exception/ExceptionResponse.java
+++ b/src/main/java/com/specialwarriors/conal/common/exception/ExceptionResponse.java
@@ -1,0 +1,5 @@
+package com.specialwarriors.conal.common.exception;
+
+public record ExceptionResponse(String message) {
+
+}

--- a/src/main/java/com/specialwarriors/conal/common/exception/GeneralException.java
+++ b/src/main/java/com/specialwarriors/conal/common/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package com.specialwarriors.conal.common.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private final BaseException exception;
+
+    public HttpStatus getStatus() {
+
+        return exception.getStatus();
+    }
+
+    public String getMessage() {
+
+        return exception.getMessage();
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/specialwarriors/conal/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.specialwarriors.conal.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ExceptionResponse> handleGeneralException(GeneralException e) {
+
+        return ResponseEntity.status(e.getStatus())
+                .body(new ExceptionResponse(e.getMessage()));
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/github_repo/domain/GithubRepo.java
+++ b/src/main/java/com/specialwarriors/conal/github_repo/domain/GithubRepo.java
@@ -1,0 +1,25 @@
+package com.specialwarriors.conal.github_repo.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "repositories")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GithubRepo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private long userId;
+}

--- a/src/main/java/com/specialwarriors/conal/github_repo/exception/GithubRepoException.java
+++ b/src/main/java/com/specialwarriors/conal/github_repo/exception/GithubRepoException.java
@@ -1,0 +1,16 @@
+package com.specialwarriors.conal.github_repo.exception;
+
+import com.specialwarriors.conal.common.exception.BaseException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GithubRepoException implements BaseException {
+
+    UNAUTHORIZED_REPO_ACCESS(HttpStatus.BAD_REQUEST, "사용자는 자신의 repo에만 접근할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/specialwarriors/conal/notification/controller/NotificationRestController.java
+++ b/src/main/java/com/specialwarriors/conal/notification/controller/NotificationRestController.java
@@ -1,0 +1,27 @@
+package com.specialwarriors.conal.notification.controller;
+
+import com.specialwarriors.conal.notification.dto.request.NotificationAgreementUpdateRequest;
+import com.specialwarriors.conal.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationRestController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping("/users/{userId}/repositories/{repositoryId}/notifications")
+    public ResponseEntity<Void> updateNotificationAgreement(@PathVariable long userId,
+            @PathVariable long repositoryId,
+            @RequestBody NotificationAgreementUpdateRequest request) {
+
+        notificationService.updateNotificationAgreement(userId, repositoryId, request);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/notification/converter/NotificationTypeConverter.java
+++ b/src/main/java/com/specialwarriors/conal/notification/converter/NotificationTypeConverter.java
@@ -1,0 +1,21 @@
+package com.specialwarriors.conal.notification.converter;
+
+import com.specialwarriors.conal.notification.enums.NotificationType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NotificationTypeConverter implements AttributeConverter<NotificationType, String> {
+
+    @Override
+    public NotificationType convertToEntityAttribute(String type) {
+
+        return NotificationType.valueOf(type);
+    }
+
+    @Override
+    public String convertToDatabaseColumn(NotificationType notificationType) {
+
+        return notificationType.name();
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/notification/domain/NotificationAgreement.java
+++ b/src/main/java/com/specialwarriors/conal/notification/domain/NotificationAgreement.java
@@ -1,0 +1,39 @@
+package com.specialwarriors.conal.notification.domain;
+
+import com.specialwarriors.conal.notification.converter.NotificationTypeConverter;
+import com.specialwarriors.conal.notification.enums.NotificationType;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "notification_agreements")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationAgreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private long repositoryId;
+
+    private boolean isAgree;
+
+    @Convert(converter = NotificationTypeConverter.class)
+    private NotificationType notificationType;
+
+    public void agree() {
+        this.isAgree = true;
+    }
+
+    public void disagree() {
+        this.isAgree = false;
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/notification/dto/request/NotificationAgreementUpdateRequest.java
+++ b/src/main/java/com/specialwarriors/conal/notification/dto/request/NotificationAgreementUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.specialwarriors.conal.notification.dto.request;
+
+public record NotificationAgreementUpdateRequest(String type, boolean isAgree) {
+
+}

--- a/src/main/java/com/specialwarriors/conal/notification/enums/NotificationType.java
+++ b/src/main/java/com/specialwarriors/conal/notification/enums/NotificationType.java
@@ -1,0 +1,5 @@
+package com.specialwarriors.conal.notification.enums;
+
+public enum NotificationType {
+    VOTE
+}

--- a/src/main/java/com/specialwarriors/conal/notification/exception/NotificationAgreementException.java
+++ b/src/main/java/com/specialwarriors/conal/notification/exception/NotificationAgreementException.java
@@ -1,0 +1,16 @@
+package com.specialwarriors.conal.notification.exception;
+
+import com.specialwarriors.conal.common.exception.BaseException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationAgreementException implements BaseException {
+
+    NOTIFICATION_AGREEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 동의 내역을 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/specialwarriors/conal/notification/repository/NotificationAgreementRepository.java
+++ b/src/main/java/com/specialwarriors/conal/notification/repository/NotificationAgreementRepository.java
@@ -1,0 +1,14 @@
+package com.specialwarriors.conal.notification.repository;
+
+import com.specialwarriors.conal.notification.domain.NotificationAgreement;
+import com.specialwarriors.conal.notification.enums.NotificationType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationAgreementRepository extends JpaRepository<NotificationAgreement, Long> {
+
+    List<NotificationAgreement> findAllByRepositoryIdAndNotificationType(long repositoryId,
+            NotificationType notificationType);
+}

--- a/src/main/java/com/specialwarriors/conal/notification/service/NotificationAgreementQuery.java
+++ b/src/main/java/com/specialwarriors/conal/notification/service/NotificationAgreementQuery.java
@@ -1,0 +1,27 @@
+package com.specialwarriors.conal.notification.service;
+
+import com.specialwarriors.conal.common.exception.GeneralException;
+import com.specialwarriors.conal.notification.domain.NotificationAgreement;
+import com.specialwarriors.conal.notification.enums.NotificationType;
+import com.specialwarriors.conal.notification.exception.NotificationAgreementException;
+import com.specialwarriors.conal.notification.repository.NotificationAgreementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationAgreementQuery {
+
+    private final NotificationAgreementRepository notificationAgreementRepository;
+
+    public NotificationAgreement findByRepositoryIdAndType(long repositoryId,
+            NotificationType type) {
+
+        return notificationAgreementRepository
+                .findAllByRepositoryIdAndNotificationType(repositoryId, type)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(
+                        NotificationAgreementException.NOTIFICATION_AGREEMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/notification/service/NotificationService.java
+++ b/src/main/java/com/specialwarriors/conal/notification/service/NotificationService.java
@@ -1,0 +1,41 @@
+package com.specialwarriors.conal.notification.service;
+
+import com.specialwarriors.conal.common.exception.GeneralException;
+import com.specialwarriors.conal.github_repo.exception.GithubRepoException;
+import com.specialwarriors.conal.notification.domain.NotificationAgreement;
+import com.specialwarriors.conal.notification.dto.request.NotificationAgreementUpdateRequest;
+import com.specialwarriors.conal.notification.enums.NotificationType;
+import com.specialwarriors.conal.user.domain.User;
+import com.specialwarriors.conal.user.service.UserQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserQuery userQuery;
+    private final NotificationAgreementQuery notificationAgreementQuery;
+
+    @Transactional
+    public void updateNotificationAgreement(long userId, long repositoryId,
+            NotificationAgreementUpdateRequest request) {
+
+        NotificationType notificationType = NotificationType.valueOf(request.type());
+        NotificationAgreement notificationAgreement = notificationAgreementQuery
+                .findByRepositoryIdAndType(repositoryId, notificationType);
+
+        // 사용자가 자신의 github repo에 접근한 것이 맞는 지 검증
+        User user = userQuery.findById(userId);
+        if (!user.hasGithubRepo(repositoryId)) {
+            throw new GeneralException(GithubRepoException.UNAUTHORIZED_REPO_ACCESS);
+        }
+
+        if (request.isAgree()) {
+            notificationAgreement.agree();
+        } else {
+            notificationAgreement.disagree();
+        }
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/user/domain/User.java
+++ b/src/main/java/com/specialwarriors/conal/user/domain/User.java
@@ -1,0 +1,35 @@
+package com.specialwarriors.conal.user.domain;
+
+import com.specialwarriors.conal.github_repo.domain.GithubRepo;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "users")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany
+    @JoinColumn(name = "user_id")
+    private List<GithubRepo> githubRepos = new ArrayList<>();
+
+    public boolean hasGithubRepo(long repositoryId) {
+
+        return githubRepos.stream().anyMatch(repo -> repo.getId() == repositoryId);
+    }
+}

--- a/src/main/java/com/specialwarriors/conal/user/exception/UserException.java
+++ b/src/main/java/com/specialwarriors/conal/user/exception/UserException.java
@@ -1,0 +1,16 @@
+package com.specialwarriors.conal.user.exception;
+
+import com.specialwarriors.conal.common.exception.BaseException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserException implements BaseException {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/specialwarriors/conal/user/repository/UserRepository.java
+++ b/src/main/java/com/specialwarriors/conal/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.specialwarriors.conal.user.repository;
+
+import com.specialwarriors.conal.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/specialwarriors/conal/user/service/UserQuery.java
+++ b/src/main/java/com/specialwarriors/conal/user/service/UserQuery.java
@@ -1,0 +1,21 @@
+package com.specialwarriors.conal.user.service;
+
+import com.specialwarriors.conal.common.exception.GeneralException;
+import com.specialwarriors.conal.user.domain.User;
+import com.specialwarriors.conal.user.exception.UserException;
+import com.specialwarriors.conal.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserQuery {
+
+    private final UserRepository userRepository;
+
+    public User findById(long userId) {
+
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 주간 투표 기능 활성화/비활성화 기능(알림 활성화/비활성화 기능)

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 개발 내역에 커스텀 비즈니스 예외, 전역 예외 핸들러 포함
- 기여도 랭킹 알림 활성화/비활성화도 이 알림 활성화/비활성화 API를 통해 이뤄짐
- `GithubRepo` 엔티티명은 JPA Repository와 명확히 구분하기 위해 `Github` prefix를 이름에 포함
- 기능 개발을 위해 `User`, `GithubRepo` 및 연관 조회 기능 구현. 추후 통합시 수정 가능

## 🔗 관련 이슈
<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->
- Close #5
